### PR TITLE
add basic keystone v3 support to keystone auth in this grafana tree

### DIFF
--- a/pkg/login/auth.go
+++ b/pkg/login/auth.go
@@ -43,7 +43,8 @@ func AuthenticateUser(query *LoginUserQuery) error {
 
 	if setting.KeystoneEnabled {
 		auther := NewKeystoneAuthenticator(setting.KeystoneURL,
-			setting.KeystoneV3)
+			setting.KeystoneV3,
+			setting.KeystoneUserDomainName)
 		err = auther.login(query)
 		if err == nil || err != ErrInvalidCredentials {
 			return err

--- a/pkg/login/keystone.go
+++ b/pkg/login/keystone.go
@@ -182,7 +182,7 @@ func (a *keystoneAuther) authenticateV3(username, password string) error {
     resp, err := client.Do(request)
     if err != nil {
         return err
-    } else if resp.StatusCode != 200 {
+    } else if resp.StatusCode != 201 {
         return errors.New("Keystone authentication failed: " + resp.Status)
     }
 

--- a/pkg/login/keystone.go
+++ b/pkg/login/keystone.go
@@ -175,6 +175,9 @@ func (a *keystoneAuther) authenticateV3(username, password string) error {
     if err != nil {
         return err
     }
+
+    a.token = auth_response.Access.Token.Id
+    return nil
 }
 
 func (a *keystoneAuther) getGrafanaUserFor(username string) (*m.User, error) {

--- a/pkg/login/keystone.go
+++ b/pkg/login/keystone.go
@@ -72,7 +72,7 @@ type v3_auth_struct struct {
 }
 
 type v3_identity_struct struct {
-    Methods string  `json:"methods"`
+    Methods []string  `json:"methods"`
     PasswordMethod v3_passwordmethod_struct  `json:"password"`
 }
 
@@ -81,7 +81,7 @@ type v3_passwordmethod_struct struct {
 }
 
 type v3_user_struct struct {
-    Name string `json:"username"`
+    Name string `json:"name"`
     Password string `json:"password"`
     Domain v3_userdomain_struct `json:"domain"`
 }
@@ -98,7 +98,7 @@ type v3_project_struct struct {
     Name string
 }
 
-func NewKeystoneAuthenticator(server string, v3 bool, userdomainaname) *keystoneAuther {
+func NewKeystoneAuthenticator(server string, v3 bool, userdomainaname string) *keystoneAuther {
     return &keystoneAuther{server: server, v3: v3, userdomainname: userdomainaname}
 }
 
@@ -167,7 +167,7 @@ func (a *keystoneAuther) authenticateV2(username, password string) error {
 
 func (a *keystoneAuther) authenticateV3(username, password string) error {
     var auth_post v3_auth_post_struct
-    auth_post.Auth.PasswordCredentials.Methods = "password"
+    auth_post.Auth.PasswordCredentials.Methods = []string{"password"}
     auth_post.Auth.PasswordCredentials.PasswordMethod.User.Name = username
     auth_post.Auth.PasswordCredentials.PasswordMethod.User.Password = password
     auth_post.Auth.PasswordCredentials.PasswordMethod.User.Domain.Name = a.userdomainname

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -136,6 +136,7 @@ var (
 	KeystoneEnabled bool
 	KeystoneURL string
 	KeystoneV3 bool
+	KeystoneUserDomainName string
 
 	// SMTP email settings
 	Smtp SmtpSettings
@@ -487,6 +488,7 @@ func NewConfigContext(args *CommandLineArgs) error {
 	KeystoneEnabled = keystone.Key("enabled").MustBool(false)
 	KeystoneURL = keystone.Key("auth_url").String()
 	KeystoneV3 = keystone.Key("v3").MustBool(false)
+	KeystoneUserDomainName = keystone.Key("user_domain_name").String()
 
 	// SSL
 


### PR DESCRIPTION
hi ryan,

i have tested this against a stable/liberty keystone with v3 - i can login with a keystone user and the org gets properly created/assigned according to the keystone project of the user.

still open: 
* the user domain name is currently "hardcoded" as config option - we should in the end add a domain input box to the grafana login dialog and get it from there - will be done soon, but we will have to discuss this with the grafana maintainer maybe to see how to best integrate this domain input box, which will only be required in the keystone auth case ...
* one variable should eventually be renamed to not contain the v2_, as it will be used for both v2 and v3
* in some ares of the code we have a bit of a mixup between the naming "tenant" (v2) and "project" (v3)

best wishes - thomas