### PR TITLE
add keystone v3 support in the grafana api keystone support as well

### DIFF
--- a/pkg/api/keystone/keystone.go
+++ b/pkg/api/keystone/keystone.go
@@ -159,9 +159,11 @@ func authenticateV3(c *middleware.Context) (string, error) {
 	auth_post.Auth.Identity.Password.User.Password = c.Session.Get(middleware.SESS_KEY_PASSWORD).(string)
 	// the user domain name is currently hardcoded via a config setting - this should change to an extra domain field in the login dialog later
 	auth_post.Auth.Identity.Password.User.Domain.Name = setting.KeystoneUserDomainName
+	// set the project domain name to the user domain name, as we only deal with the projects for the domain the user logged in with
+	auth_post.Auth.Scope.Project.Domain.Name = setting.KeystoneUserDomainName
 	b, _ := json.Marshal(auth_post)
 
-	request, err := http.NewRequest("POST", server + "/v3/tokens", bytes.NewBuffer(b))
+	request, err := http.NewRequest("POST", server + "/v3/auth/tokens", bytes.NewBuffer(b))
 	if err != nil {
 		return "", err
 	}

--- a/pkg/api/keystone/keystone.go
+++ b/pkg/api/keystone/keystone.go
@@ -40,6 +40,47 @@ type v2_token_struct struct {
 	Issued_at string
 }
 
+type v3_auth_post_struct struct {
+    Auth v3_auth_struct  `json:"auth"`
+}
+
+type v3_auth_struct struct {
+    Identity v3_identity_struct  `json:"identity"`
+    Scope v3_scope_struct  `json:"scope"`
+}
+
+type v3_identity_struct struct {
+    Methods []string  `json:"methods"`
+    Password v3_passwordmethod_struct  `json:"password"`
+}
+
+type v3_passwordmethod_struct struct {
+    User v3_user_struct `json:"user"`
+}
+
+type v3_user_struct struct {
+    Name string `json:"name"`
+    Password string `json:"password"`
+    Domain v3_userdomain_struct `json:"domain"`
+}
+
+type v3_userdomain_struct struct {
+    Name string `json:"name"`
+}
+
+type v3_scope_struct struct {
+    Project v3_project_struct `json:"project"`
+}
+
+type v3_project_struct struct {
+    Name string `json:"name"`
+    Domain v3_projectdomain_struct `json:"domain"`
+}
+
+type v3_projectdomain_struct struct {
+    Name string `json:"name"`
+}
+
 func getUserName(c *middleware.Context) (string, error) {
 	userQuery := m.GetUserByIdQuery{Id: c.Session.Get(middleware.SESS_KEY_USERID).(int64)}
 	if err := bus.Dispatch(&userQuery); err != nil {
@@ -101,8 +142,40 @@ func authenticateV2(c *middleware.Context) (string, error) {
 }
 
 func authenticateV3(c *middleware.Context) (string, error) {
-	// TODO implement
-	return "", errors.New("Keystone v3 authentication not implemented")
+	server := setting.KeystoneURL
+
+	var auth_post v3_auth_post_struct
+	auth_post.Auth.Identity.Methods = []string{"password"}
+	if username, err := getUserName(c); err != nil {
+		return "", err
+	} else {
+		auth_post.Auth.Identity.Password.User.Name = username
+	}
+	if tenant, err := getOrgName(c); err != nil {
+		return "", err
+	} else {
+		auth_post.Auth.Scope.Project.Name = tenant
+	}
+	auth_post.Auth.Identity.Password.User.Password = c.Session.Get(middleware.SESS_KEY_PASSWORD).(string)
+	// the user domain name is currently hardcoded via a config setting - this should change to an extra domain field in the login dialog later
+	auth_post.Auth.Identity.Password.User.Domain.Name = setting.KeystoneUserDomainName
+	b, _ := json.Marshal(auth_post)
+
+	request, err := http.NewRequest("POST", server + "/v3/tokens", bytes.NewBuffer(b))
+	if err != nil {
+		return "", err
+	}
+
+	client := &http.Client{}
+	resp, err := client.Do(request)
+	if err != nil {
+		return "", err
+	} else if resp.StatusCode != 201 {
+		return "", errors.New("Keystone authentication failed: " + resp.Status)
+	}
+
+	// in keystone v3 the token is in the response header
+	return resp.Header.Get("X-Subject-Token"), nil
 }
 
 func GetToken(c *middleware.Context) (string, error) {

--- a/pkg/login/keystone.go
+++ b/pkg/login/keystone.go
@@ -56,12 +56,12 @@ type v3_auth_post_struct struct {
 }
 
 type v3_auth_struct struct {
-    PasswordCredentials v3_identity_struct  `json:"identity"`
+    Identity v3_identity_struct  `json:"identity"`
 }
 
 type v3_identity_struct struct {
     Methods []string  `json:"methods"`
-    PasswordMethod v3_passwordmethod_struct  `json:"password"`
+    Password v3_passwordmethod_struct  `json:"password"`
 }
 
 type v3_passwordmethod_struct struct {
@@ -151,11 +151,11 @@ func (a *keystoneAuther) authenticateV2(username, password string) error {
 
 func (a *keystoneAuther) authenticateV3(username, password string) error {
     var auth_post v3_auth_post_struct
-    auth_post.Auth.PasswordCredentials.Methods = []string{"password"}
-    auth_post.Auth.PasswordCredentials.PasswordMethod.User.Name = username
-    auth_post.Auth.PasswordCredentials.PasswordMethod.User.Password = password
+    auth_post.Auth.Identity.Methods = []string{"password"}
+    auth_post.Auth.Identity.Password.User.Name = username
+    auth_post.Auth.Identity.Password.User.Password = password
     // the user domain name is currently hardcoded via a config setting - this should change to an extra domain field in the login dialog later
-    auth_post.Auth.PasswordCredentials.PasswordMethod.User.Domain.Name = a.userdomainname
+    auth_post.Auth.Identity.Password.User.Domain.Name = a.userdomainname
     b, _ := json.Marshal(auth_post)
 
     request, err := http.NewRequest("POST", a.server + "/v3/auth/tokens", bytes.NewBuffer(b))


### PR DESCRIPTION
hi ryan,

this is the addition of keystone v3 support to your added keystone support for the grafana api. i have tested it here locally with my keystone v3 devstack system and it works. this pull request also contains some minor cosmetic changes to the keystone v3 login code, so that the variable names match the json property fields better and thus the code should hopefully be easier to understand.

feel free to contact me in case anything is unclear - best wishes - thomas